### PR TITLE
Allow DATABASE_URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ This repository contains a minimal point-of-sale demo. It includes:
 3. Visit `http://localhost:3000` to use the web frontend. The API is available at `http://localhost:8000` and MySQL listens on port `3307`.
 
 Stop the containers with `Ctrl+C` and run `docker-compose down` when finished.
+
+## Backend configuration
+
+The API can connect to the database in two ways. If the `DATABASE_URL` environment
+variable is set, its value is used directly as the SQLAlchemy connection string.
+Otherwise the backend builds the DSN from `DB_USER`, `DB_PASSWORD`, `DB_HOST`,
+`DB_PORT` and `DB_NAME`.

--- a/backend/.env.development
+++ b/backend/.env.development
@@ -1,6 +1,7 @@
 FRONTEND_ORIGIN=http://localhost:3000
 
 # ---------- Database ----------
+# `DATABASE_URL` を設定した場合はこちらが優先されます
 DB_USER=root
 DB_PASSWORD=limit500?
 DB_HOST=db      # ここはdocker-compose上のMySQLサービス名「db」

--- a/backend/.env.production
+++ b/backend/.env.production
@@ -1,2 +1,3 @@
 FRONTEND_ORIGIN=https://pos-frontend.ashystone-fb341e56.japaneast.azurecontainerapps.io
+# この値を設定すると DB_* 系の変数よりも優先されます
 DATABASE_URL=mysql+pymysql://adminuser:limit500?@posmysqlserver-sea.mysql.database.azure.com:3306/pos_app_db?ssl_ca=/usr/local/share/ca-certificates/digicert.pem&ssl_verify_cert=true


### PR DESCRIPTION
## Summary
- support DATABASE_URL in backend
- document env var precedence
- clarify env var precedence in development/prod examples

## Testing
- `python -m py_compile backend/app/db.py`


------
https://chatgpt.com/codex/tasks/task_e_6856689109a483228886ba4411551a3e