### PR TITLE
Fix DB URL handling and SSL context

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -23,18 +23,15 @@ DATABASE_URL_ENV = os.getenv("DATABASE_URL")
 
 
 if DATABASE_URL_ENV:
+    # Use provided connection string directly
     DATABASE_URL = DATABASE_URL_ENV
 
-    # DATABASE_URL に ssl_ca=... が含まれていても、PyMySQL 用の connect_args を明示
+    # If connecting to Azure MySQL, ensure CA file is explicitly passed
     if "mysql.database.azure.com" in DATABASE_URL_ENV:
-        CONNECT_ARGS = {
-            "ssl": {
-                "ca": "/etc/ssl/certs/digicert.pem"
-            }
-        }
+        CONNECT_ARGS = {"ssl": {"ca": CA_CERT}}
     else:
         CONNECT_ARGS = {}
-
+else:
     # ---------- DSN 組み立て ----------
     # PASSWORD に記号が含まれていても正しく接続できるよう URL.create() を利用
     BASE_DSN = URL.create(

--- a/backend/app/init_data.py
+++ b/backend/app/init_data.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 load_dotenv(dotenv_path=".env.production")
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import text, create_engine
-from app.db import SessionLocal, Base, engine
+from app.db import SessionLocal, Base, engine, CA_CERT
 from app.models import Product
 import os
 
@@ -21,7 +21,7 @@ def create_database_if_not_exists():
     db_name = db_url.rsplit("/", 1)[1].split("?")[0]  # pos_app_db
 
     # DBなし接続エンジンで CREATE DATABASE 実行
-    engine_wo_db = create_engine(base_url)
+    engine_wo_db = create_engine(base_url, connect_args={"ssl": {"ca": CA_CERT}})
     with engine_wo_db.connect() as conn:
         conn.execute(text(f"CREATE DATABASE IF NOT EXISTS {db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"))
         print(f"✓ データベース `{db_name}` の存在を確認（または作成）しました。")


### PR DESCRIPTION
## Summary
- ensure DATABASE_URL env var isn't overwritten
- set SSL CA when creating DB from init script

## Testing
- `python -m py_compile backend/app/db.py backend/app/init_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6857d64fbfec8322a4bb57495806440c