### PR TITLE
Add pytest config and MySQL tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ jobs:
           tags: ${{ env.REGISTRY }}/pos-backend:${{ env.IMAGE_TAG }}
           no-cache: true          # ← 1 回だけ付ける
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Run tests
+        run: pytest backend/tests -q
+
       - name: Build & push frontend
         uses: docker/build-push-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ The API can connect to the database in two ways. If the `DATABASE_URL` environme
 variable is set, its value is used directly as the SQLAlchemy connection string.
 Otherwise the backend builds the DSN from `DB_USER`, `DB_PASSWORD`, `DB_HOST`,
 `DB_PORT` and `DB_NAME`.
+
+## Running tests
+
+Unit tests live under `backend/tests`. Install the backend requirements and run
+
+```bash
+pytest
+```
+
+Tests spin up a temporary MySQL server using `pytest-mysql`, so Docker or
+MySQL does not need to be running beforehand.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ SQLAlchemy>=2.0
 pydantic
 python-dotenv
 pymysql         # ← ここが MySQL 接続ドライバ
+pytest
+pytest-mysql

--- a/backend/tests/test_init_data.py
+++ b/backend/tests/test_init_data.py
@@ -1,0 +1,40 @@
+import importlib
+import pathlib
+import sys
+from pytest_mysql.factories import mysql, mysql_proc
+
+mysql_proc_fixture = mysql_proc()
+mysql_fixture = mysql("mysql_proc_fixture", dbname="pos_app_test")
+
+def test_init_data(mysql_fixture, monkeypatch):
+    # Ensure backend package is importable
+    backend_dir = pathlib.Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(backend_dir))
+    user = mysql_fixture.user.decode() if isinstance(mysql_fixture.user, bytes) else mysql_fixture.user
+    url = (
+        f"mysql+pymysql://{user}@localhost/pos_app_test?"
+        f"unix_socket={mysql_fixture.unix_socket}"
+    )
+    monkeypatch.setenv("DATABASE_URL", url)
+    import app.db as db
+    import app.init_data as init_data
+    importlib.reload(db)
+    importlib.reload(init_data)
+    monkeypatch.setattr(db, "CA_CERT", "/etc/ssl/certs/ca-certificates.crt", raising=False)
+    monkeypatch.setattr(init_data, "CA_CERT", "/etc/ssl/certs/ca-certificates.crt", raising=False)
+
+    def _create_db():
+        with mysql_fixture.cursor() as cur:
+            cur.execute(
+                "CREATE DATABASE IF NOT EXISTS pos_app_test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
+            )
+
+    monkeypatch.setattr(init_data, "create_database_if_not_exists", _create_db)
+
+    init_data.main()
+
+    with mysql_fixture.cursor() as cur:
+        cur.execute("SHOW TABLES")
+        tables = {row[0] for row in cur.fetchall()}
+    for t in ["prd_mst", "trd", "trd_dtl"]:
+        assert t in tables


### PR DESCRIPTION
## Summary
- include pytest and pytest-mysql in backend requirements
- test init_data using a temporary MySQL instance
- run pytest in CI workflow
- document running tests in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: MySQL server has gone away)*

------
https://chatgpt.com/codex/tasks/task_e_6857e8878d748322a4747755a4a78ca3