### PR TITLE
Fix tests by installing MySQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r backend/requirements.txt
 
+      - name: Install MySQL server
+        run: sudo apt-get update && sudo apt-get install -y mysql-server
+
       - name: Run tests
         run: pytest backend/tests -q
 

--- a/README.md
+++ b/README.md
@@ -34,5 +34,12 @@ Unit tests live under `backend/tests`. Install the backend requirements and run
 pytest
 ```
 
-Tests spin up a temporary MySQL server using `pytest-mysql`, so Docker or
-MySQL does not need to be running beforehand.
+Tests spin up a temporary MySQL server using `pytest-mysql`. The fixture
+requires the `mysqld` binary to be available on the system. On most Linux
+systems installing the `mysql-server` package is sufficient:
+
+```bash
+sudo apt-get update && sudo apt-get install -y mysql-server
+```
+
+After installing MySQL, simply run the tests as shown above.


### PR DESCRIPTION
## Summary
- ensure CI installs MySQL so `pytest-mysql` can start a server
- document MySQL requirement for running tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857fb7301b88322994537e26569d06f