### PR TITLE
docs: clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Otherwise the backend builds the DSN from `DB_USER`, `DB_PASSWORD`, `DB_HOST`,
 
 ## Running tests
 
-Unit tests live under `backend/tests`. Install the backend requirements and run
+Unit tests live under `backend/tests`. Install the backend requirements first:
+
+```bash
+pip install -r backend/requirements.txt
+```
+
+Then run the tests with
 
 ```bash
 pytest


### PR DESCRIPTION
## Summary
- clarify how to install Python dependencies before running tests

## Testing
- `pytest -q` *(fails: CalledProcessError: Command 'mysqld --initialize-insecure ...' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_685800d7b1048322a6e6202d515a24a7