### PR TITLE
Use local MariaDB fixture in tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,78 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import pwd
+import pathlib
+
+import pytest
+import pymysql
+
+
+@pytest.fixture(scope="session")
+def mysql_fixture(tmp_path_factory):
+    data_dir = pathlib.Path(tempfile.mkdtemp(prefix="mysql_data_", dir="/tmp"))
+    socket_path = data_dir / "mysql.sock"
+    pid_file = data_dir / "mysqld.pid"
+
+    mysql_user = pwd.getpwnam("mysql")
+    os.chown(data_dir, mysql_user.pw_uid, mysql_user.pw_gid)
+
+    subprocess.run(
+        [
+            "mariadb-install-db",
+            f"--datadir={data_dir}",
+            "--user=mysql",
+            "--auth-root-authentication-method=normal",
+        ],
+        check=True,
+    )
+
+    proc = subprocess.Popen(
+        [
+            "mariadbd",
+            f"--datadir={data_dir}",
+            f"--socket={socket_path}",
+            "--skip-networking",
+            "--user=mysql",
+            f"--pid-file={pid_file}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    for _ in range(100):
+        if proc.poll() is not None:
+            out, err = proc.communicate()
+            raise RuntimeError(
+                "mariadbd failed to start",
+                out.decode(),
+                err.decode(),
+            )
+        try:
+            conn = pymysql.connect(user="root", unix_socket=str(socket_path))
+            conn.close()
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        proc.terminate()
+        proc.wait()
+        raise RuntimeError("mariadbd did not start in time")
+
+    conn = pymysql.connect(user="root", unix_socket=str(socket_path), autocommit=True)
+    conn.user = b"root"
+    conn.unix_socket = str(socket_path)
+
+    yield conn
+
+    with conn.cursor() as cur:
+        cur.execute("SHOW DATABASES LIKE 'pos_app_test'")
+        if cur.fetchone():
+            cur.execute("DROP DATABASE pos_app_test")
+    conn.close()
+    proc.terminate()
+    proc.wait()
+    shutil.rmtree(data_dir, ignore_errors=True)
+

--- a/backend/tests/test_init_data.py
+++ b/backend/tests/test_init_data.py
@@ -1,10 +1,6 @@
 import importlib
 import pathlib
 import sys
-from pytest_mysql.factories import mysql, mysql_proc
-
-mysql_proc_fixture = mysql_proc()
-mysql_fixture = mysql("mysql_proc_fixture", dbname="pos_app_test")
 
 def test_init_data(mysql_fixture, monkeypatch):
     # Ensure backend package is importable
@@ -34,6 +30,8 @@ def test_init_data(mysql_fixture, monkeypatch):
     monkeypatch.setattr(init_data, "create_database_if_not_exists", _create_db)
 
     init_data.main()
+
+    mysql_fixture.select_db("pos_app_test")
 
     with mysql_fixture.cursor() as cur:
         cur.execute("SHOW TABLES")


### PR DESCRIPTION
## Summary
- create pytest fixture that spins up a temporary MariaDB server
- drop dependency on pytest-mysql fixtures and update the test

## Testing
- `pytest -q backend/tests/test_init_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68580d3a405c832296e42782a1748d15