### PR TITLE
Remove pytest-mysql from backend requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Then run the tests with
 pytest
 ```
 
-Tests spin up a temporary MySQL server using `pytest-mysql`. The fixture
-requires the `mysqld` binary to be available on the system. On most Linux
-systems installing the `mysql-server` package is sufficient:
+Tests spin up a temporary MySQL server by invoking the local `mariadbd`
+binary directly. The fixture requires the MariaDB or MySQL server
+utilities (e.g. `mariadbd`, `mariadb-install-db`) to be available on the
+system. On most Linux systems installing the `mysql-server` (or
+`mariadb-server`) package is sufficient:
 
 ```bash
 sudo apt-get update && sudo apt-get install -y mysql-server

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,4 +5,3 @@ pydantic
 python-dotenv
 pymysql         # ← ここが MySQL 接続ドライバ
 pytest
-pytest-mysql


### PR DESCRIPTION
## Summary
- drop pytest-mysql requirement
- update docs about testing fixture

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68580f35d8ac83229ff3f5e6c44ed1a7