### PR TITLE
Enable custom ENV_FILE loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ variable is set, its value is used directly as the SQLAlchemy connection string.
 Otherwise the backend builds the DSN from `DB_USER`, `DB_PASSWORD`, `DB_HOST`,
 `DB_PORT` and `DB_NAME`.
 
+Environment variables are loaded from the file specified by `ENV_FILE`. When the
+variable is not set, `.env.production` is used.
+For local development you can create a custom env file and start the services
+with:
+
+```bash
+ENV_FILE=.env.local docker-compose up --build
+```
+
 ## Running tests
 
 Unit tests live under `backend/tests`. Install the backend requirements first:

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -4,7 +4,9 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.engine import URL
 import os
 from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv(".env.production"), override=False)
+
+ENV_FILE = os.getenv("ENV_FILE", ".env.production")
+load_dotenv(find_dotenv(ENV_FILE), override=False)
 
 # ────────────────────────────────
 # 環境変数（.env）を利用

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,10 @@
 # backend/app/main.py
 from __future__ import annotations
 from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv(".env.production"), override=False)
+import os
+
+ENV_FILE = os.getenv("ENV_FILE", ".env.production")
+load_dotenv(find_dotenv(ENV_FILE), override=False)
 from datetime import datetime
 from typing import List, Optional
 from decimal import Decimal, ROUND_HALF_UP
@@ -16,8 +19,6 @@ from .db import SessionLocal
 from .models import Product, Transaction, TransactionDetail
 
 from app.init_data import main as init_main
-
-import os
 
 # ✅ FastAPIインスタンスは1回だけ作成（ここでタイトルも設定）
 app = FastAPI(title="POS API MVP", version="0.1.0")


### PR DESCRIPTION
## Summary
- allow specifying env file via `ENV_FILE` in `main.py` and `db.py`
- document `ENV_FILE` usage in README

## Testing
- `pip install -r backend/requirements.txt`
- `pytest backend/tests -q` *(fails: getpwnam(): name not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858d70ba38c83229ce9df277b538797