### PR TITLE
Update env defaults for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Otherwise the backend builds the DSN from `DB_USER`, `DB_PASSWORD`, `DB_HOST`,
 
 Environment variables are loaded from the file specified by `ENV_FILE`. When the
 variable is not set, `.env.production` is used.
-For local development you can create a custom env file and start the services
+For local development use the provided development files and start the services
 with:
 
 ```bash
-ENV_FILE=.env.local docker-compose up --build
+ENV_FILE=.env.development docker-compose up --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     container_name: pos-backend
     restart: unless-stopped
     env_file:
-      - ./backend/.env.production
+      - ./backend/${ENV_FILE:-.env.development}
     depends_on:
       - db
     ports:
@@ -33,11 +33,11 @@ services:
     build:
       context: ./frontend                  # frontend/Dockerfile
       args:
-        ENV_FILE: .env.production          # ← build-argsで本番用を指定
+        ENV_FILE: ${ENV_FILE:-.env.development}  # ← build-argsで切替可能
     container_name: pos-frontend
     restart: unless-stopped
     env_file:
-      - ./frontend/.env.production
+      - ./frontend/${ENV_FILE:-.env.development}
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- load development env files in docker-compose
- document command to start services with development settings

## Testing
- `pip install -r backend/requirements.txt`
- `ENV_FILE=.env.development uvicorn app.main:app` and curl preflight check

------
https://chatgpt.com/codex/tasks/task_e_6858ee9c45ec8322b53be96121f03531