### PR TITLE
Expose ENV_FILE to running services

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Otherwise the backend builds the DSN from `DB_USER`, `DB_PASSWORD`, `DB_HOST`,
 `DB_PORT` and `DB_NAME`.
 
 Environment variables are loaded from the file specified by `ENV_FILE`. When the
-variable is not set, `.env.production` is used.
+variable is not set, `.env.production` is used. Docker Compose mounts this file
+into each service and also exposes its name as the `ENV_FILE` environment
+variable so the running containers know which configuration was applied.
 For local development use the provided development files and start the services
 with:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     restart: unless-stopped
     env_file:
       - ./backend/${ENV_FILE:-.env.development}
+    environment:
+      ENV_FILE: ${ENV_FILE:-.env.development}
     depends_on:
       - db
     ports:
@@ -38,6 +40,8 @@ services:
     restart: unless-stopped
     env_file:
       - ./frontend/${ENV_FILE:-.env.development}
+    environment:
+      ENV_FILE: ${ENV_FILE:-.env.development}
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- pass ENV_FILE into backend and frontend containers
- document the ENV_FILE behaviour in README

## Testing
- `docker-compose` wasn't available so configuration couldn't be validated

------
https://chatgpt.com/codex/tasks/task_e_6858fcdba1908322ab1baa74e84cc53f