### PR TITLE
Fix relative imports in init_data

### DIFF
--- a/backend/app/init_data.py
+++ b/backend/app/init_data.py
@@ -6,8 +6,8 @@ from dotenv import load_dotenv, find_dotenv
 ENV_FILE = os.getenv("ENV_FILE", ".env.production")
 load_dotenv(find_dotenv(ENV_FILE), override=False)
 
-from app.db import CA_CERT, Base, SessionLocal, engine, DATABASE_URL, CONNECT_ARGS
-from app.models import Product
+from .db import Base, SessionLocal, engine, DATABASE_URL, CONNECT_ARGS
+from .models import Product
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError


### PR DESCRIPTION
## Summary
- import `db` and `models` using relative paths so running `init_data.py` works as a script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859115303b88322969f0dadeeb98f27